### PR TITLE
Create variables to enable GPRA build

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -199,7 +199,7 @@ deps = {
   'src/third_party/gflags/src':
     Var('chromium_git') + '/external/github.com/gflags/gflags' + '@' + '03bebcb065c83beff83d50ae025a55a4bf94dfca',
   'src/third_party/webrtc':
-    Var('deps_webrtc_git') + '/owt-deps-webrtc' + '@' + 'cbd2aecc1c29083adcc4d35d9cc0a584e6c3c7d6',
+    Var('deps_webrtc_git') + '/owt-deps-webrtc' + '@' + '0af7871efaa7124431ba0950526555c943dab3e2',
   'src/third_party/accessibility_test_framework': {
     'packages': [
         {

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ rtc_build_examples = false
 target_cpu = "x64"
 is_debug = false
 ````
+- If you wish to use the Intel GPRA BWE library, you need to add three additional variables, shown below. The lib root should be the directory that contains `gpra_lib.lib`, and the header root should be directory that contains `grpa_bwe.h`. Using the // syntax, the path is relative to your `src` directory. You can also use absolute paths.
+```
+owt_gpra_lib_root = "//path/to/libs/x64"
+owt_gpra_header_root = "//path/to/include"
+owt_use_gpra = true
+```
 - Run `ninja -C out/release-x64` to finish the build. Output owt.lib will be under out/release-x64/obj/owt/talk/owt.lib; rename it to owt-release.lib for copying to cloud-gaming dependency directories.
 - Copy the header files under src/talk/owt/sdk/include/cpp/ to the cloud-gaming include directories.
 

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -72,4 +72,8 @@ declare_args() {
 
   # Some non-Chromium builds don't support building java targets.
   enable_java_templates = true
+
+  owt_gpra_lib_root = ""
+  owt_gpra_header_root = ""
+  owt_use_gpra = false
 }


### PR DESCRIPTION
Tested w/ and w/o owt_use_grpa in args. Also checked that gclient sync pulls the correct owt-deps-webrtc code. All seems to check out.

Note, this is based on the previous commit in your branch because of that compile error.