### PR TITLE
Revert "Fix build issues reported by clang on Ubuntu."

### DIFF
--- a/talk/owt/sdk/base/customizedframescapturer.h
+++ b/talk/owt/sdk/base/customizedframescapturer.h
@@ -60,7 +60,7 @@ class CustomizedFramesCapturer : public webrtc::VideoCaptureModule, public Encod
   virtual int32_t CaptureSettings(webrtc::VideoCaptureCapability& settings) override;
 // EncodedStreamProviderSink implementation
   virtual void OnStreamProviderFrame(const std::vector<uint8_t>& buffer,
-                                     const EncodedImageMetaData& meta_data) override;
+                                     const EncodedImageMetaData& meta_data);
   virtual int32_t SetCaptureRotation(webrtc::VideoRotation rotation) override;
   virtual bool SetApplyRotation(bool enable) override { 
     return false; 

--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -12,8 +12,8 @@ namespace base {
 PeerConnectionChannel::PeerConnectionChannel(
     PeerConnectionChannelConfiguration configuration)
     : configuration_(configuration),
-      peer_connection_(nullptr),
-      factory_(nullptr) {}
+      factory_(nullptr),
+      peer_connection_(nullptr) {}
 PeerConnectionChannel::~PeerConnectionChannel() {
   if (peer_connection_ != nullptr) {
     peer_connection_->Close();

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -169,10 +169,10 @@ void PeerConnectionDependencyFactory::
   }
   // If still video factory is not in place, use internal factory.
   if (!encoder_factory.get()) {
-    encoder_factory = webrtc::CreateBuiltinVideoEncoderFactory();
+    encoder_factory = std::move(webrtc::CreateBuiltinVideoEncoderFactory());
   }
   if (!decoder_factory.get()) {
-    decoder_factory = webrtc::CreateBuiltinVideoDecoderFactory();
+    decoder_factory = std::move(webrtc::CreateBuiltinVideoDecoderFactory());
   }
 #else
 #error "Unsupported platform."

--- a/talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h
@@ -27,26 +27,19 @@ enum class OWT_EXPORT VideoRendererType {
   kARGB,
   kD3D11Handle,
 };
-/// Video buffer and its information.
+/// Video buffer and its information
 struct OWT_EXPORT VideoBuffer {
-  /// TODO: It doens't look good to define `buffer` as void* and has its
-  /// ownership. Delete void* is a undefined behavior. Cast it to other types
-  /// before delete is a workaround. It's dangerous because developer may store
-  /// other types of data to `buffer`.
-  void* buffer;
-  /// Resolution for the Video buffer.
+  /// Video buffer. If is native, 
+   void* buffer;
+  /// Resolution for the Video buffer
   Resolution resolution;
-  // Buffer type.
+  // Buffer type
   VideoBufferType type;
   ~VideoBuffer() {
     if (type != VideoBufferType::kD3D11Handle)
-      delete[] static_cast<uint8_t*>(buffer);
+      delete[] buffer;
     else
-#if defined(WEBRTC_WIN)
-      delete static_cast<D3D11VAHandle*>(buffer);
-#else
-      RTC_NOTREACHED();
-#endif
+      delete buffer;
   }
 };
 /// VideoRenderWindow wraps a native Window handle

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -258,7 +258,7 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   std::atomic<bool> stop_send_needed_;
   bool remote_side_offline_;
   bool block_data_send_ = false;
-  std::atomic<bool> ended_;
+  std::atomic<bool> ended_ = false;
   bool local_stop_triggered_ = false;
   mutable std::mutex api_lock_;
 };


### PR DESCRIPTION
Reverts taste1981/oms-client-native#19 as Windows build fails with this change:

talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h(46): error C2061: syntax error: identifier 'D3D11VAHandle'